### PR TITLE
Check if function parameter has @escaping attribute

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -54,7 +54,8 @@ let package = Package(
             dependencies: [
                 .product(name: "SwiftSyntax", package: "swift-syntax"),
                 .product(name: "SwiftParser", package: "swift-syntax"),
-                .product(name: "SwiftIndexStore", package: "swift-indexstore")
+                .product(name: "SwiftIndexStore", package: "swift-indexstore"),
+                .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
             ]
         ),
         .plugin(

--- a/Sources/WeakSelfCheckCore/ClosureWeakSelfChecker.swift
+++ b/Sources/WeakSelfCheckCore/ClosureWeakSelfChecker.swift
@@ -56,7 +56,7 @@ fileprivate final class _ClosureWeakSelfCheckerSyntaxVisitor: SyntaxVisitor {
 
         // Check if `self` or ``self`` is included in parameter list
         if let parameterClause {
-            if let items = parameterClause.as(ClosureParameterListSyntax.self),
+            if let items = parameterClause.as(ClosureParameterClauseSyntax.self)?.parameters,
                items.contains(where: {
                    if let secondName = $0.secondName {
                        return secondName.tokenKind.isSelf

--- a/Sources/WeakSelfCheckCore/Extension/FunctionParameterSyntax+.swift
+++ b/Sources/WeakSelfCheckCore/Extension/FunctionParameterSyntax+.swift
@@ -1,0 +1,78 @@
+//
+//  FunctionParameterSyntax+.swift
+//
+//
+//  Created by p-x9 on 2024/06/14
+//
+//
+
+import Foundation
+import SwiftSyntax
+
+extension FunctionParameterSyntax {
+    /// A boolean value that indicates whatever the parameter is a closure type.
+    var isFunctionType: Bool {
+        type.isFunctionType
+    }
+
+    /// A boolean value that indicates whether the parameter has `@escaping` attribute.
+    var isEscaping: Bool {
+        guard let type = type.as(AttributedTypeSyntax.self) else {
+            return false
+        }
+        let isEscaping = type.attributes.contains(where: {
+            if case let .attribute(attribute) = $0 {
+                return attribute.isEscaping
+            }
+            return false
+        })
+
+        return isEscaping
+    }
+}
+
+extension AttributeSyntax {
+    /// A boolean value that indicates whatever the attribute is `@escaping` or not.
+    var isEscaping: Bool {
+        guard let identifierType = attributeName.as(IdentifierTypeSyntax.self) else {
+            return false
+        }
+        return identifierType.name.tokenKind == .identifier("escaping")
+    }
+}
+
+extension TypeSyntaxProtocol {
+    /// A boolean value that indicates whatever the type is a closure type.
+    var isFunctionType: Bool {
+        if kind == .functionType {
+            return true
+        }
+
+        if let type = self.as(MemberTypeSyntax.self) {
+            if type.name.tokenKind == .identifier("Optional"),
+               let genericArgumentClause = type.genericArgumentClause,
+               let argument = genericArgumentClause.arguments.first {
+                return argument.argument.isFunctionType
+            }
+            return type.baseType.isFunctionType
+        }
+        if let type  = self.as(AttributedTypeSyntax.self) {
+            return type.baseType.isFunctionType
+        }
+        if let type = self.as(OptionalTypeSyntax.self) {
+            return type.wrappedType.isFunctionType
+        }
+        if let type = self.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
+            return type.wrappedType.isFunctionType
+        }
+
+        if let type = self.as(IdentifierTypeSyntax.self),
+           type.name.tokenKind == .identifier("Optional"),
+           let genericArgumentClause = type.genericArgumentClause,
+           let argument = genericArgumentClause.arguments.first {
+            return argument.argument.isFunctionType
+        }
+
+        return false
+    }
+}

--- a/Sources/WeakSelfCheckCore/Extension/FunctionParameterSyntax+.swift
+++ b/Sources/WeakSelfCheckCore/Extension/FunctionParameterSyntax+.swift
@@ -15,6 +15,11 @@ extension FunctionParameterSyntax {
         type.isFunctionType
     }
 
+    /// A boolean value that indicates whatever the parameter is a optional type.
+    var isOptionalType: Bool {
+        type.isOptionalType
+    }
+
     /// A boolean value that indicates whether the parameter has `@escaping` attribute.
     var isEscaping: Bool {
         guard let type = type.as(AttributedTypeSyntax.self) else {
@@ -38,41 +43,5 @@ extension AttributeSyntax {
             return false
         }
         return identifierType.name.tokenKind == .identifier("escaping")
-    }
-}
-
-extension TypeSyntaxProtocol {
-    /// A boolean value that indicates whatever the type is a closure type.
-    var isFunctionType: Bool {
-        if kind == .functionType {
-            return true
-        }
-
-        if let type = self.as(MemberTypeSyntax.self) {
-            if type.name.tokenKind == .identifier("Optional"),
-               let genericArgumentClause = type.genericArgumentClause,
-               let argument = genericArgumentClause.arguments.first {
-                return argument.argument.isFunctionType
-            }
-            return type.baseType.isFunctionType
-        }
-        if let type  = self.as(AttributedTypeSyntax.self) {
-            return type.baseType.isFunctionType
-        }
-        if let type = self.as(OptionalTypeSyntax.self) {
-            return type.wrappedType.isFunctionType
-        }
-        if let type = self.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
-            return type.wrappedType.isFunctionType
-        }
-
-        if let type = self.as(IdentifierTypeSyntax.self),
-           type.name.tokenKind == .identifier("Optional"),
-           let genericArgumentClause = type.genericArgumentClause,
-           let argument = genericArgumentClause.arguments.first {
-            return argument.argument.isFunctionType
-        }
-
-        return false
     }
 }

--- a/Sources/WeakSelfCheckCore/Extension/IndexStoreSymbol+.swift
+++ b/Sources/WeakSelfCheckCore/Extension/IndexStoreSymbol+.swift
@@ -13,7 +13,7 @@ import SwiftParser
 import SwiftSyntaxBuilder
 
 extension IndexStoreSymbol {
-    var demangledSymbol: String? {
+    var demangledName: String? {
         guard let usr else { return nil }
 
         // swift symbol
@@ -47,7 +47,7 @@ extension IndexStoreSymbol {
     }
 
     private func _functionDeclString(_ name: String) -> String? {
-        guard var string = demangledSymbol else { return nil }
+        guard var string = demangledName else { return nil }
 
         if string.starts(with: "c:") { return nil }
 

--- a/Sources/WeakSelfCheckCore/Extension/IndexStoreSymbol+.swift
+++ b/Sources/WeakSelfCheckCore/Extension/IndexStoreSymbol+.swift
@@ -1,0 +1,95 @@
+//
+//  IndexStoreSymbol+.swift
+//
+//
+//  Created by p-x9 on 2024/06/14
+//
+//
+
+import Foundation
+import SwiftIndexStore
+import SwiftSyntax
+import SwiftParser
+import SwiftSyntaxBuilder
+
+extension IndexStoreSymbol {
+    var demangledSymbol: String? {
+        guard let usr else { return nil }
+
+        // swift symbol
+        if usr.hasPrefix("s:") {
+            let index = usr.lastIndex(of: ":").map { usr.index($0, offsetBy: -1) }
+            if let index {
+                var symbol = String(usr[index...])
+                symbol.replaceSubrange(symbol.startIndex...symbol.index(symbol.startIndex, offsetBy: 1), with: "$S")
+                return stdlib_demangleName(symbol)
+            }
+        }
+        return stdlib_demangleName(usr)
+    }
+}
+
+extension IndexStoreSymbol {
+    func functionDecl(_ name: String) -> FunctionDeclSyntax? {
+        guard language == .swift,
+              let string = _functionDeclString(name) else {
+            return nil
+        }
+
+        let decl: DeclSyntax = """
+        \(raw: string)
+        """
+
+        let functionDecl = decl
+            .as(FunctionDeclSyntax.self)
+
+        return functionDecl
+    }
+
+    private func _functionDeclString(_ name: String) -> String? {
+        guard var string = demangledSymbol else { return nil }
+
+        if string.starts(with: "c:") { return nil }
+
+        if string.starts(with: "("),
+           let closeIndex = string.indexForMatchingBracket(open: "(", close: ")") {
+            let index = string.index(string.startIndex, offsetBy: closeIndex)
+            string = String(string[index...])
+        }
+
+        string = string.parentMemberStripped
+
+        return "func " + string + " {}"
+    }
+}
+
+extension String {
+    fileprivate var parentMemberStripped: String {
+        guard let index = firstIndex(of: "(") else {
+            return self
+        }
+        var functionName = String(self[..<index])
+        let functionExpr = String(self[index...])
+
+        var depth = 0
+        var currentIndex = functionName.index(before: functionName.endIndex)
+        while functionName.startIndex < currentIndex {
+            let current = functionName[currentIndex]
+            if current == ">" { depth += 1 }
+            if current == "<" { depth -= 1 }
+
+            if depth == 0 && current == "." {
+                currentIndex = functionName.index(after: currentIndex)
+                break
+            }
+
+            currentIndex = functionName.index(before: currentIndex)
+        }
+
+        functionName = String(
+            functionName[currentIndex..<functionName.endIndex]
+        )
+
+        return "\(functionName)\(functionExpr)"
+    }
+}

--- a/Sources/WeakSelfCheckCore/Extension/String+.swift
+++ b/Sources/WeakSelfCheckCore/Extension/String+.swift
@@ -20,3 +20,25 @@ extension String {
         }
     }
 }
+
+extension String {
+    /// Finds the index of the matching closing bracket for a given opening bracket.
+    /// - Parameters:
+    ///   - open: The opening bracket character.
+    ///   - close: The closing bracket character.
+    /// - Returns: The index of the matching closing bracket if found, otherwise `nil`.
+    /// - Complexity: O(n), where n is the length of the string.
+    func indexForMatchingBracket(
+        open: Character,
+        close: Character
+    ) -> Int? {
+        var depth = 0
+        for (index, char) in enumerated() {
+            depth += (char == open) ? 1 : (char == close) ? -1 : 0
+            if depth == 0 {
+                return index
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/WeakSelfCheckCore/Extension/TypeSyntaxProtocol+.swift
+++ b/Sources/WeakSelfCheckCore/Extension/TypeSyntaxProtocol+.swift
@@ -1,0 +1,66 @@
+//
+//  TypeSyntaxProtocol+.swift
+//  swift-weak-self-check
+//
+//  Created by p-x9 on 2024/11/11
+//  
+//
+
+import Foundation
+import SwiftSyntax
+
+extension TypeSyntaxProtocol {
+    /// A boolean value that indicates whatever the type is a closure type.
+    var isFunctionType: Bool {
+        if kind == .functionType {
+            return true
+        }
+
+        if let type = self.as(MemberTypeSyntax.self) {
+            if type.name.tokenKind == .identifier("Optional"),
+               let genericArgumentClause = type.genericArgumentClause,
+               let argument = genericArgumentClause.arguments.first {
+                return argument.argument.isFunctionType
+            }
+            return type.baseType.isFunctionType
+        }
+        if let type  = self.as(AttributedTypeSyntax.self) {
+            return type.baseType.isFunctionType
+        }
+        if let type = self.as(OptionalTypeSyntax.self) {
+            return type.wrappedType.isFunctionType
+        }
+        if let type = self.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
+            return type.wrappedType.isFunctionType
+        }
+
+        if let type = self.as(IdentifierTypeSyntax.self),
+           type.name.tokenKind == .identifier("Optional"),
+           let genericArgumentClause = type.genericArgumentClause,
+           let argument = genericArgumentClause.arguments.first {
+            return argument.argument.isFunctionType
+        }
+
+        return false
+    }
+}
+
+extension TypeSyntaxProtocol {
+    var isOptionalType: Bool {
+        if let type = self.as(OptionalTypeSyntax.self) {
+            return true
+        }
+        if let type = self.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
+            return true
+        }
+        if let type = self.as(MemberTypeSyntax.self),
+           type.name.tokenKind == .identifier("Optional") {
+            return true
+        }
+        if let type = self.as(IdentifierTypeSyntax.self),
+           type.name.tokenKind == .identifier("Optional") {
+            return true
+        }
+        return false
+    }
+}

--- a/Sources/WeakSelfCheckCore/SelfAccessDetector.swift
+++ b/Sources/WeakSelfCheckCore/SelfAccessDetector.swift
@@ -20,9 +20,8 @@ public enum SelfAccessDetector {
 fileprivate final class _SelfAccessDetectSyntaxVisitor: SyntaxVisitor {
     public private(set) var isSelfUsed: Bool = false
 
-    override func visit(_ node: MemberAccessExprSyntax) -> SyntaxVisitorContinueKind {
-        if let base = node.base?.as(DeclReferenceExprSyntax.self),
-           base.baseName.tokenKind == .keyword(.`self`) {
+    override func visit(_ node: DeclReferenceExprSyntax) -> SyntaxVisitorContinueKind {
+        if node.baseName.tokenKind == .keyword(.`self`) {
             isSelfUsed = true
             return .skipChildren
         }

--- a/Sources/WeakSelfCheckCore/Util/demangle.swift
+++ b/Sources/WeakSelfCheckCore/Util/demangle.swift
@@ -1,0 +1,56 @@
+//
+//  demangle.swift
+//
+//
+//  Created by p-x9 on 2024/06/14
+//
+//
+
+import Foundation
+
+@_silgen_name("swift_demangle")
+internal func _stdlib_demangleImpl(
+    mangledName: UnsafePointer<CChar>?,
+    mangledNameLength: UInt,
+    outputBuffer: UnsafeMutablePointer<CChar>?,
+    outputBufferSize: UnsafeMutablePointer<UInt>?,
+    flags: UInt32
+) -> UnsafeMutablePointer<CChar>?
+
+internal func stdlib_demangleName(
+    _ mangledName: String
+) -> String {
+    guard !mangledName.isEmpty else { return mangledName }
+    return mangledName.utf8CString.withUnsafeBufferPointer { mangledNameUTF8 in
+        let demangledNamePtr = _stdlib_demangleImpl(
+            mangledName: mangledNameUTF8.baseAddress,
+            mangledNameLength: numericCast(mangledNameUTF8.count - 1),
+            outputBuffer: nil,
+            outputBufferSize: nil,
+            flags: 0
+        )
+
+        if let demangledNamePtr {
+            return String(cString: demangledNamePtr)
+        }
+        return mangledName
+    }
+}
+
+internal func stdlib_demangleName(
+    _ mangledName: UnsafePointer<CChar>
+) -> UnsafePointer<CChar> {
+
+    let demangledNamePtr = _stdlib_demangleImpl(
+        mangledName: mangledName,
+        mangledNameLength: numericCast(strlen(mangledName)),
+        outputBuffer: nil,
+        outputBufferSize: nil,
+        flags: 0
+    )
+    if let demangledNamePtr {
+        return .init(demangledNamePtr)
+    }
+    return mangledName
+}
+

--- a/Sources/WeakSelfCheckCore/WeakSelfChecker.swift
+++ b/Sources/WeakSelfCheckCore/WeakSelfChecker.swift
@@ -62,6 +62,7 @@ public final class WeakSelfChecker: SyntaxVisitor {
             guard let parameter else { return true }
 
             if parameter.isFunctionType,
+               !parameter.type.isOptionalType,
                !parameter.isEscaping {
                 return false
             }

--- a/Sources/WeakSelfCheckCore/WeakSelfChecker.swift
+++ b/Sources/WeakSelfCheckCore/WeakSelfChecker.swift
@@ -36,6 +36,39 @@ public final class WeakSelfChecker: SyntaxVisitor {
             return .visitChildren
         }
 
+        func hasEscaping(
+            for label: String?,
+            isTrailing: Bool = false
+        ) -> Bool {
+            guard let funcDecl = try? functionDecl(for: node) else {
+                return true
+            }
+            let parameters = funcDecl.signature.parameterClause.parameters
+
+            var parameter: FunctionParameterSyntax?
+
+            if let label {
+                parameter = parameters.first(where: {
+                    $0.secondName?.trimmedDescription == label ||
+                    $0.firstName.trimmedDescription == label
+                })
+            } else if parameters.count(where: \.isFunctionType) == 1 {
+                parameter = parameters.first(where: {
+                    $0.isFunctionType
+                })
+            }
+            // TODO: Handle function which has multiple closures without label
+
+            guard let parameter else { return true }
+
+            if parameter.isFunctionType,
+               !parameter.isEscaping {
+                return false
+            }
+
+            return true
+        }
+
 #if canImport(SwiftSyntax510)
         let arguments = node.arguments
 #else
@@ -46,20 +79,23 @@ public final class WeakSelfChecker: SyntaxVisitor {
             guard let closure = argument.expression.as(ClosureExprSyntax.self) else {
                 continue
             }
-            if !ClosureWeakSelfChecker.check(closure, in: fileName, indexStore: indexStore) {
+            if !ClosureWeakSelfChecker.check(closure, in: fileName, indexStore: indexStore),
+               hasEscaping(for: argument.label?.trimmedDescription) {
                 report(for: closure)
             }
         }
 
         // Check trailing closure
         if let trailingClosure = node.trailingClosure,
-           !ClosureWeakSelfChecker.check(trailingClosure, in: fileName, indexStore: indexStore) {
+           !ClosureWeakSelfChecker.check(trailingClosure, in: fileName, indexStore: indexStore),
+           hasEscaping(for: nil, isTrailing: true) {
             report(for: trailingClosure)
         }
 
         // Check additional trailing closures
         for closure in node.additionalTrailingClosures {
-            if !ClosureWeakSelfChecker.check(closure.closure, in: fileName, indexStore: indexStore) {
+            if !ClosureWeakSelfChecker.check(closure.closure, in: fileName, indexStore: indexStore),
+               hasEscaping(for: closure.label.trimmedDescription, isTrailing: true) {
                 report(for: closure.closure)
             }
         }
@@ -123,5 +159,67 @@ extension WeakSelfChecker {
         }
 
         return false
+    }
+}
+
+extension WeakSelfChecker {
+    private func functionDecl(for callExpr: FunctionCallExprSyntax) throws -> FunctionDeclSyntax? {
+        guard let occurrence = try functionCallOccurrence(for: callExpr) else {
+            return nil
+        }
+
+        var calledExpression = callExpr.calledExpression
+        if let member = calledExpression.as(MemberAccessExprSyntax.self) {
+            calledExpression = ExprSyntax(member.declName)
+        }
+        return occurrence.symbol.functionDecl(
+            calledExpression.trimmedDescription
+        )
+    }
+
+    private func functionCallOccurrence(for callExpr: FunctionCallExprSyntax) throws -> IndexStoreOccurrence? {
+        guard let indexStore else { return nil }
+
+        var calledExpression = callExpr.calledExpression
+
+        if let member = calledExpression.as(MemberAccessExprSyntax.self) {
+            calledExpression = ExprSyntax(member.declName)
+        }
+
+        let location = calledExpression.startLocation(
+            converter: .init(
+                fileName: fileName,
+                tree: calledExpression.root
+            )
+        )
+
+        var occurrence: IndexStoreOccurrence?
+
+        try indexStore.forEachUnits(includeSystem: false) { unit in
+            try indexStore.forEachRecordDependencies(for: unit) { dependency in
+                guard case let .record(record) = dependency,
+                      record.filePath == fileName else {
+                    return true
+                }
+
+                try indexStore.forEachOccurrences(for: record) {
+                    let l = $0.location
+                    if !l.isSystem,
+                       l.line == location.line && l.column == location.column,
+                       $0.roles.contains([.reference, .call]),
+                       [.instanceMethod, .classMethod, .staticMethod, .constructor, .function, .conversionFunction].contains($0.symbol.kind) {
+                        occurrence = $0
+                        return false
+                    }
+                    return true
+                } // forEachOccurrences
+
+                return false
+            } // forEachRecordDependencies
+
+            return occurrence == nil
+        } // forEachUnits
+
+        return occurrence
     }
 }


### PR DESCRIPTION
A weak self is required if the `@escaping` attribute is specified.

Previously, warnings were issued regardless of whether `@escaping` was specified or not